### PR TITLE
恢复 postJson 用法

### DIFF
--- a/src/Conversation/Client.php
+++ b/src/Conversation/Client.php
@@ -41,7 +41,7 @@ class Client extends BaseClient
      */
     public function sendCorporationMessage($params)
     {
-        return $this->client->post('topapi/message/corpconversation/asyncsend_v2', $params);
+        return $this->client->postJson('topapi/message/corpconversation/asyncsend_v2', $params);
     }
 
     /**

--- a/tests/Conversation/ClientTest.php
+++ b/tests/Conversation/ClientTest.php
@@ -32,7 +32,7 @@ class ClientTest extends TestCase
     {
         $this->make(Client::class)->sendCorporationMessage($params = ['foo' => 'bar'])
             ->assertPostUri('topapi/message/corpconversation/asyncsend_v2')
-            ->assertPostFormParams($params);
+            ->assertPostJson($params);
     }
 
     /** @test */


### PR DESCRIPTION
之前被修改后，'msg’ 要加  json_encode，这没有什么意义
'msg'=> json_encode(['msgtype'=> "text", 'text'=>['content'=> '测试 ']])

如果用 postJson，则直接写， 这样更合理
'msg'=>['msgtype'=> "text", 'text'=>['content'=> '测试 ']]

#40 #79 

